### PR TITLE
Created shared with me and shared by me APIs and revoke-access

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,8 @@ app.use("/api", authRouter);
 app.use("/api", profileRouter);
 app.use("/api", feedRouter);
 app.use("/api", statsRouter);
-app.use("/api", accessRouter);
+// Mount access routes under /api/access to align with frontend paths
+app.use("/api/access", accessRouter);
 
 connectDb()
   .then(() => {

--- a/src/routes/access.js
+++ b/src/routes/access.js
@@ -1,9 +1,12 @@
 import express from "express";
 import { userAuth } from "../middlewares/auth.js";
-import { giveAccess } from "../controllers/accessController.js";
+import { giveAccess, getSharedWithMe, getSharedByMe, revokeAccess } from "../controllers/accessController.js";
 
 const accessRouter = express.Router();
 
 accessRouter.post("/give-access", userAuth, giveAccess);
+accessRouter.get("/shared-with-me", userAuth, getSharedWithMe);
+accessRouter.get("/shared-by-me", userAuth, getSharedByMe);
+accessRouter.delete("/revoke-access/:feedId/:email", userAuth, revokeAccess);
 
 export default accessRouter;


### PR DESCRIPTION
## Summary by Sourcery

Add APIs and routing for managing credential sharing visibility and revocation.

New Features:
- Expose an endpoint to list credentials shared with the authenticated user, including decrypted data and share metadata.
- Expose an endpoint to list credentials owned by the authenticated user that have been shared with others, including decrypted data and sharing details.
- Expose an endpoint for credential owners to revoke access for a specific email from a shared credential.

Enhancements:
- Adjust access route mounting to sit under /api/access to align with frontend paths.