### PR TITLE
fixed issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ubuntu
           key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 30m
           script: |
             cd ~/project/SafeKeyz
             git pull origin main

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install -g nodemon && npm install
+RUN npm install -g nodemon && npm ci
 
 # Only copy source after dependencies to optimize cache
 COPY . .


### PR DESCRIPTION
## Summary by Sourcery

Use npm ci for dependency installation in the Docker image and adjust deployment workflow SSH action settings.

Build:
- Switch Dockerfile dependency installation from npm install to npm ci for reproducible builds.

CI:
- Configure the deployment GitHub Actions workflow SSH step with an explicit 30-minute command timeout.